### PR TITLE
Add: public enum to project schema

### DIFF
--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -45,7 +45,7 @@ const resolvers = (models) => ({
     async project(root, { id }, context) {
       const userId = getUserId(context)
       const project = await db.findRecord(models.Project, id)
-      if (project.owners.indexOf(userId) > -1) {
+      if (project.owners.indexOf(userId) > -1 || project.public.includes('READ')) {
         return project
       }
       throw new Error(`Unauthorized Action`)
@@ -56,7 +56,7 @@ const resolvers = (models) => ({
       const task = await db.findRecord(models.Task, id)
       const section = await db.findRecord(models.Section, task.section)
       const project = await db.findRecord(models.Project, section.project)  
-      if (project.owners.indexOf(userId) > -1) {
+      if (project.owners.indexOf(userId) > -1 || project.public.includes('READ')) {
         return task
       }
       throw new Error(`Unauthorized Action`)

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -16,6 +16,7 @@ const schema = `
   type Project {
     id: ID!
     title: String
+    public: String
     created: Int!
     owners: [User]
     sections: [Section]
@@ -52,7 +53,7 @@ const schema = `
     signup(first: String!, last: String!, email: String!, password: String!): AuthPayload
     login(email: String!, password: String!): AuthPayload
 
-    createProject(owners: [ID] title: String!): Project
+    createProject(owners: [ID] title: String! public: String): Project
     createSection(project: ID, task: ID, title: String, position: Int): Section
     createTask(section: ID!, title: String, description: String, due: Int, completed: Boolean, position: String!): Task
 

--- a/models/project.js
+++ b/models/project.js
@@ -13,6 +13,12 @@ const projectSchema = new mongoose.Schema({
     unique: false,
     required: true,
   },
+  public: {
+    type: String,
+    enum: ['NONE', 'READ', 'READ/WRITE'],
+    default: 'READ',
+    unique: false,
+  },
   owners: [{
     type: mongoose.Schema.Types.ObjectId, 
     ref: 'User' 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- [x ] Feature
- [ ] Issue

## Related Issue/Task
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Description
<!--- Describe your changes in detail -->

Added a 'public' enum to the projects schema. Added an additional check during project/task retrieval to return the project even if the user isn't an owner if it is set to public.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This will certain project boards to be viewable by all users regardless of ownership if they are set to read only.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested locally, unit tests to be added later.

## Changelog
<!--- User friendly bullet points of improvements made. -->

## Screenshots (if appropriate):