### PR TITLE
ADD: docker-compose deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # production
 /build
 
+# docker stuff
+/data
+
 # misc
 .DS_Store
 .env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-
+# TODO: We don't always want to pull the latest for stability
 FROM node:latest
 
-RUN mkdir /app
+# Create image directory structure
+RUN mkdir /app 
+COPY . /app
+
+# Initialize the server dependencies
 WORKDIR /app
-COPY package.json /app/
-EXPOSE 3030:3030 27017:27017
+RUN npm install 
 
-RUN npm install
-
+# Start the server
 CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ There has also been a implementation done in Golang but development has been pau
 #### Prerequisites:
 - MongoDB
 - NodeJS
+- Docker / Docker Compose
 
 #### Run the following commands to install:
 
 - `git clone \<repo url\>`
 - `cd kickit-backend`
-- `yarn`
-- `yarn start`
+- `docker-compose up`
 - the server will be available at localhost:3030
 
 #### Routes for development:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,18 @@
 version: "3"
 services:
-  app:
-    container_name: app
+  server:
+    container_name: server
     restart: always
     build: .
     ports:
       - "3030:3030"
-      - "27017:27017"
-    links:
-      - mongo
-    depends_on: 
+    depends_on:
       - mongo
   mongo:
     container_name: mongo
-    image: mongo
+    restart: always
+    build: ./mongo_docker
     volumes:
       - ./data:/data/db
-    ports:
-      - "27017:27017"
+    expose:
+      - "27017"

--- a/mongo_docker/Dockerfile
+++ b/mongo_docker/Dockerfile
@@ -1,0 +1,13 @@
+# TODO: We don't always want to pull the latest for stability
+FROM mongo:latest
+
+# Create image directory structure
+RUN mkdir -p /data/db
+COPY . /data
+WORKDIR /data
+
+# Copy mongo daemon initialization script to bin
+COPY start_mongo.sh /usr/local/bin
+
+# Initialize the mongo daemon
+CMD ["start_mongo.sh"]

--- a/mongo_docker/mongod.conf
+++ b/mongo_docker/mongod.conf
@@ -1,0 +1,43 @@
+# mongod.conf
+
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
+
+# Where and how to store data.
+storage:
+  dbPath: /data/db
+  journal:
+    enabled: true
+#  engine:
+#  mmapv1:
+#  wiredTiger:
+
+# where to write logging data.
+systemLog:
+  destination: file
+  logAppend: true
+  path: /var/log/mongodb/mongod.log
+
+# network interfaces
+net:
+  port: 27017
+  bindIpAll: true
+
+
+# how the process runs
+processManagement:
+  timeZoneInfo: /usr/share/zoneinfo
+
+#security:
+
+#operationProfiling:
+
+#replication:
+
+#sharding:
+
+## Enterprise-Only Options:
+
+#auditLog:
+
+#snmp:

--- a/mongo_docker/start_mongo.sh
+++ b/mongo_docker/start_mongo.sh
@@ -1,0 +1,1 @@
+mongod --config ./mongod.conf

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const { makeExecutableSchema } = require('graphql-tools');
 const { getUserId } = require('./utils')
 const tabs = require('./tabs.js')
 
-const HOST = 'localhost'
+const HOST = 'server'
 const PORT = 3030
 
 
@@ -51,9 +51,6 @@ const graphiql = {
 
 const endpoints = [api, graphiql]
 
-
-mongoose.connect('mongodb://localhost:27017/kickit_db1');
-
 const init = async () => {
   const server = Hapi.server({
     host: HOST,
@@ -71,9 +68,22 @@ const init = async () => {
 }
 
 process.on('unhandledRejection', (err) => {
-
     console.log(err)
     process.exit(1)
 })
 
-init()
+const connectToMongo = async () => {
+    try {
+        await mongoose.connect('mongodb://mongo:27017/kickit_db1', (err) => {
+            if (err) {
+                setTimeout(connectToMongo, 5000)
+            } else {
+                init()
+            }
+        })
+    } catch (err) {
+        console.error('Error while connecting to mongo DB - retrying in 5 seconds...')
+    }
+}
+
+connectToMongo()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- [x] Feature

## Related Issue/Task
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#22 

## Description
<!--- Describe your changes in detail -->
Supports deploying the backend over two docker containers (one for mongodb and the other for the actual node server itself). This is a step towards the test deployment environment.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improves modularity of kickit-backed across any machine using docker.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Changelog
<!--- User friendly bullet points of improvements made. -->

## Screenshots (if appropriate):